### PR TITLE
[SHIPIT-0714] dashboard updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Widgets are plotted on a grid with 24 vertical units. Widgets can be as narrow a
 | `width` **req**      | number   | between `[1, 24]`                       |
 | `height` **req**     | number   |                                         |
 | `metrics` **req**    | metric[] |                                         |
+| `stat` **req**       | string   |                                         |
 | `properties` **req** | map(any) |                                         |
 | — `.title` **req**   | string   |                                         |
 | — `.stacked` **req** | boolean  |                                         |

--- a/dashboard.tf
+++ b/dashboard.tf
@@ -1,23 +1,14 @@
 locals {
   dashboards = var.dashboards == null ? {} : var.dashboards
-  #  dashboards = { for key, dashboard in local.dashboards_prep:
-  #    key => merge(dashboard, {
-  #    widgets = [ for widget in lookup(dashboard, "widgets", []):
-  #    merge(widget, {
-  #      metadata = merge(lookup(widget, "metadata", {}), {
-  ##        id = lookup(widget, "id")
-  ##        expression = lookup(widget, "expression", null)
-  #      })
-  #    })
-  #    ]
-  #  })
-  #  }
 }
 
 resource "aws_cloudwatch_dashboard" "dashboard" {
   for_each       = local.dashboards
   dashboard_name = lookup(each.value, "name")
-  dashboard_body = jsonencode({
+
+  # cloudwatch hates null values in map, so we need to strip them out of JSON
+  # (tf doesn't have a function to remove null elements from maps)
+  dashboard_body = replace(jsonencode({
     widgets = [
     for widget in lookup(each.value, "widgets", [ ]):
     {
@@ -26,7 +17,6 @@ resource "aws_cloudwatch_dashboard" "dashboard" {
       y          = lookup(widget, "y")
       width      = lookup(widget, "width")
       height     = lookup(widget, "height")
-      stat       = lookup(widget, "statistic", null)
       properties = merge(lookup(widget, "properties", {}), {
         # converting the dimensions key-value map into a list of alternating
         # key & value elements requires us to
@@ -41,28 +31,28 @@ resource "aws_cloudwatch_dashboard" "dashboard" {
         #
         # @formatter:off
         metrics = [ for metric in lookup(widget, "metrics", [ ]):
-          flatten(concat([
-            # for expressions, these would produce `["", ""]`, which can be reduced to []
-            compact([
-              lookup(metric, "namespace", ""),
-              lookup(metric, "metric", "")
-            ]),
-            flatten([ for key, val in lookup(metric, "dimensions", {}): [ key, val ] ]),
-            # auto-inject id and expression for metric properties
-            # for stat, we basically set as follows: metadata.stat, metric.statistic, null (defer to properties.stat)
-            [ merge(
-#                { stat = lookup(metric, "statistic", null) },
-                lookup(metric, "metadata", {}),
-                {
-                  id         = lookup(metric, "id")
-                  expression = lookup(metric, "expression", null)
-                }
-            ) ]
-          ]))
+        flatten(concat([
+          # for expressions, these would produce `["", ""]`, which can be reduced to []
+          compact([
+            lookup(metric, "namespace", ""),
+            lookup(metric, "metric", "")
+          ]),
+          flatten([ for key, val in lookup(metric, "dimensions", {}): [ key, val ] ]),
+          # auto-inject id and expression for metric properties
+          # for stat, we basically set as follows: metadata.stat, metric.statistic, null (defer to properties.stat)
+          [ merge(
+          #                { stat = lookup(metric, "statistic", null) },
+          lookup(metric, "metadata", {}),
+          {
+            id         = lookup(metric, "id")
+            expression = lookup(metric, "expression", null)
+          }
+          ) ]
+        ]))
         ]
         # @formatter:on
       })
     }
     ]
-  })
+  }), "/\"[^\"]+\":null,?/", "")
 }

--- a/dashboard.tf
+++ b/dashboard.tf
@@ -37,16 +37,17 @@ resource "aws_cloudwatch_dashboard" "dashboard" {
             lookup(metric, "namespace", ""),
             lookup(metric, "metric", "")
           ]),
+          # unzip map
           flatten([ for key, val in lookup(metric, "dimensions", {}): [ key, val ] ]),
           # auto-inject id and expression for metric properties
           # for stat, we basically set as follows: metadata.stat, metric.statistic, null (defer to properties.stat)
           [ merge(
-          #                { stat = lookup(metric, "statistic", null) },
-          lookup(metric, "metadata", {}),
-          {
-            id         = lookup(metric, "id")
-            expression = lookup(metric, "expression", null)
-          }
+            { stat = lookup(metric, "statistic", null) },
+            lookup(metric, "metadata", {}),
+            {
+              id         = lookup(metric, "id")
+              expression = lookup(metric, "expression", null)
+            }
           ) ]
         ]))
         ]

--- a/dashboard.tf
+++ b/dashboard.tf
@@ -6,9 +6,17 @@ resource "aws_cloudwatch_dashboard" "dashboard" {
   for_each       = local.dashboards
   dashboard_name = lookup(each.value, "name")
 
-  # cloudwatch hates null values in map, so we need to strip them out of JSON
-  # (tf doesn't have a function to remove null elements from maps)
-  dashboard_body = replace(jsonencode({
+  # cloudwatch hates null values in map, so we need to strip them out of JSON.
+  # TF doesn't have any way to do this so we need to do some regex replaces
+  #
+  # 1. replace `"key":null` with ``. this may produce any of the following:
+  #   - `{,"key2":...}`
+  #   - `{"key2":"val2",,"..."}`
+  #   - `"key2":"val2",}`
+  # 2. remove any consecutive dangling commas (e.g. `"val2",,...` -> `"key":"val",...`
+  # 3. remove dangling commas from `{,`
+  # 4. remove dangling commas from `,}`
+  dashboard_body = replace(replace(replace(replace(jsonencode({
     widgets = [
     for widget in lookup(each.value, "widgets", [ ]):
     {
@@ -37,17 +45,17 @@ resource "aws_cloudwatch_dashboard" "dashboard" {
             lookup(metric, "namespace", ""),
             lookup(metric, "metric", "")
           ]),
-          # unzip map
+          # unzip map into [ [k1,v1], [k2,v2], ... ]
           flatten([ for key, val in lookup(metric, "dimensions", {}): [ key, val ] ]),
-          # auto-inject id and expression for metric properties
-          # for stat, we basically set as follows: metadata.stat, metric.statistic, null (defer to properties.stat)
+          # auto-inject: id and expression for metric properties
+          # for stat, we basically set as follows: metadata.stat, metric.statistic, "Sum"
           [ merge(
-            { stat = lookup(metric, "statistic", null) },
-            lookup(metric, "metadata", {}),
-            {
-              id         = lookup(metric, "id")
-              expression = lookup(metric, "expression", null)
-            }
+          { stat = lookup(metric, "statistic", "Sum") },
+          lookup(metric, "metadata", {}),
+          {
+            id         = lookup(metric, "id")
+            expression = lookup(metric, "expression", null)
+          }
           ) ]
         ]))
         ]
@@ -55,5 +63,5 @@ resource "aws_cloudwatch_dashboard" "dashboard" {
       })
     }
     ]
-  }), "/\"[^\"]+\":null,?/", "")
+  }), "/\"[\\w]+\":null/", ""), "/,,+/", ","), "/\\{,/", "{"), "/,\\}/", "}")
 }


### PR DESCRIPTION
fixed dashboard generation logic:

1. strip null key-value pairs from map (through string manipulation)
2. use `metric.statistic` as default value for `metric.metadata.stat` (still preserves explicit `stat`)